### PR TITLE
Support UI

### DIFF
--- a/Assets/Shaders/HSLRangeShader.shader
+++ b/Assets/Shaders/HSLRangeShader.shader
@@ -39,6 +39,12 @@ Shader "Custom/HSLRangeShader"
        _HSLRangeMin ("HSL Affect Range Min", Range(0, 1)) = 0
        _HSLRangeMax ("HSL Affect Range Max", Range(0, 1)) = 1
        _HSLAAdjust ("HSLA Adjust", Vector) = (0, 0, 0, 0)
+       _StencilComp ("Stencil Comparison", Float) = 8
+       _Stencil ("Stencil ID", Float) = 0
+       _StencilOp ("Stencil Operation", Float) = 0
+       _StencilWriteMask ("Stencil Write Mask", Float) = 255
+       _StencilReadMask ("Stencil Read Mask", Float) = 255
+       _ColorMask ("Color Mask", Float) = 15
     }
     SubShader
     {

--- a/Assets/Shaders/HSLRangeShader.shader
+++ b/Assets/Shaders/HSLRangeShader.shader
@@ -54,6 +54,16 @@ Shader "Custom/HSLRangeShader"
             "Queue" = "Transparent"
         }
 
+        Stencil
+        {
+            Ref [_Stencil]
+            Comp [_StencilComp]
+            Pass [_StencilOp]
+            ReadMask [_StencilReadMask]
+            WriteMask [_StencilWriteMask]
+        }
+        ColorMask [_ColorMask]
+
         Pass
         {
             Cull Off

--- a/Assets/Shaders/HSVRangeShader.shader
+++ b/Assets/Shaders/HSVRangeShader.shader
@@ -39,6 +39,12 @@ Shader "Custom/HSVRangeShader"
        _HSVRangeMin ("HSV Affect Range Min", Range(0, 1)) = 0
        _HSVRangeMax ("HSV Affect Range Max", Range(0, 1)) = 1
        _HSVAAdjust ("HSVA Adjust", Vector) = (0, 0, 0, 0)
+       _StencilComp ("Stencil Comparison", Float) = 8
+       _Stencil ("Stencil ID", Float) = 0
+       _StencilOp ("Stencil Operation", Float) = 0
+       _StencilWriteMask ("Stencil Write Mask", Float) = 255
+       _StencilReadMask ("Stencil Read Mask", Float) = 255
+       _ColorMask ("Color Mask", Float) = 15
     }
     SubShader
     {

--- a/Assets/Shaders/HSVRangeShader.shader
+++ b/Assets/Shaders/HSVRangeShader.shader
@@ -54,6 +54,16 @@ Shader "Custom/HSVRangeShader"
             "Queue" = "Transparent"
         }
 
+        Stencil
+        {
+            Ref [_Stencil]
+            Comp [_StencilComp]
+            Pass [_StencilOp]
+            ReadMask [_StencilReadMask]
+            WriteMask [_StencilWriteMask]
+        }
+        ColorMask [_ColorMask]
+
         Pass
         {
             Cull Off


### PR DESCRIPTION
This adds some code which makes the shader compatible with UI elements. In it's current state I get warnings about missing properties when using the shader in the UI and it also doesn't support the UI mask component. The code is taken from the UI-Default.shader included in Unity.

* Adds specific properties that the UI system expects to find on shaders.
* Adds the stencil code required for the UI Mask component to work.

I don't believe that this has any performance impact because it's only related to the UI system, my hope is that this code isn't triggered when using other renderers.

I also don't know if you feel like the UI system is a target use case for these shaders. I have made these changes to the shaders I am using so I thought it might be useful to others as well.

Thanks for sharing these shaders!